### PR TITLE
Fix bug in Stomper.leave/join - Unsubscribing now works as intended

### DIFF
--- a/src/components/views/Home.js
+++ b/src/components/views/Home.js
@@ -294,7 +294,7 @@ const Home = (props) => {
       </Button>
       <div className="login form">
         <FormField
-          label="gameToLeave"
+          label="gameToJoin"
           value={gameIdToLeave}
           onChange={(un) => setgameIdToJoin(un)}
         />

--- a/src/helpers/Stomp.js
+++ b/src/helpers/Stomp.js
@@ -25,7 +25,7 @@ class Stomper {
   join(endpoint, callback) {
     if (this.openChannels.indexOf(endpoint) === -1) {
       this.openChannels.push(endpoint);
-      this.stompClient.subscribe(endpoint, callback);
+      this.stompClient.subscribe(endpoint, callback, {id : endpoint}); // add the endpoint also as ID
       console.log("Subscribed to " + endpoint);
     }
   }


### PR DESCRIPTION
Stomper.join now sets an id equal to endpoint
When Stomper.leave calls unsubscribe, the chanel is correctly unsusbcribed